### PR TITLE
Rotate prompts forever!

### DIFF
--- a/app/services/prompt.js
+++ b/app/services/prompt.js
@@ -172,7 +172,7 @@ export default Service.extend({
   getPastPrompts() {
     let promptIndex = getPromptIndex();
 
-    return prompts.slice(0, promptIndex);
+    return prompts.slice(promptIndex, prompts.length);
   },
 
   buildPromptInfo() {
@@ -189,7 +189,8 @@ export default Service.extend({
 });
 
 function getPromptIndex() {
-  return Math.floor((Date.now() - new Date("2016-07-10T04:00:00.000Z")) / (1000 * 60 * 60 * 24));
+  let daysSinceLaunch = Math.floor((Date.now() - new Date("2016-07-10T04:00:00.000Z")) / (1000 * 60 * 60 * 24));
+  return prompts.length-(daysSinceLaunch%prompts.length);
 }
 
 function didCompletePrompt(info) {


### PR DESCRIPTION
This is a simple enhancement to prevent the site from ever running out of prompts. Instead of looking for a prompt for every X days since launch, 2016-07-10, the app now takes the length of the prompts and subtracts a remainder of the days since launch divided by number of prompts. This means the countdown now runs backwards up the list of prompts and will loop back to the end to restart.